### PR TITLE
Default to finding types files in the same directory as the yaml file

### DIFF
--- a/yamltypes/yamlconfig.py
+++ b/yamltypes/yamlconfig.py
@@ -209,6 +209,9 @@ class YamlConfigBuilder(object):
                  specfn=None, yamltypes_dirs=[], needSpec=True):
         if customizations is None:
             customizations = []
+        # if not specified, default to the directory the yaml file is in
+        if not yamltypes_dirs:
+            yamltypes_dirs.append(os.path.dirname(os.path.abspath(fn)))
         self._dict = self._yamlLoad(fn)
         self.mixCustomizations(os.path.basename(fn), customizations)
         self._ns = Namespace(self._dict)


### PR DESCRIPTION
If we don't specify a YAML type file directory, this makes us default to including the same directory as the YAML file itself. This helps make imports work when running the simple cli checker, and makes it more obvious for people just trying to validate files.
